### PR TITLE
fix on finding correct type-specific view when property is nullable enum

### DIFF
--- a/FormFactory.Example/FormFactory.Example.csproj
+++ b/FormFactory.Example/FormFactory.Example.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Models\AccountModel.cs" />
     <Compile Include="Models\Person.cs" />
     <Compile Include="Models\RegisterModel.cs" />
+    <Compile Include="Models\Titles.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Views\Home\Test.generated.cs" />
   </ItemGroup>
@@ -172,6 +173,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\Account\Register.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\FormFactory\Property.FormFactory.Example.Models.Titles.cshtml" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />

--- a/FormFactory.Example/Models/RegisterModel.cs
+++ b/FormFactory.Example/Models/RegisterModel.cs
@@ -18,9 +18,8 @@ namespace FormFactory.Example.Models
         [Compare("Password", ErrorMessage = "Passwords did not match")]
         public string ConfirmPassword { get; set; }
 
-        [Required]
         [Display(Name = "Title")]
-        public string Title { get; set; }
+        public Titles? Title { get; set; }
 
         [Required]
         [Display(Name = "First name")]

--- a/FormFactory.Example/Models/Titles.cs
+++ b/FormFactory.Example/Models/Titles.cs
@@ -1,0 +1,12 @@
+namespace FormFactory.Example.Models
+{
+    public enum Titles
+    {
+        Mr,
+        Mrs,
+        Ms,
+        Dr,
+        Prof,
+        Rev
+    }
+}

--- a/FormFactory.Example/Views/Shared/FormFactory/Property.FormFactory.Example.Models.Titles.cshtml
+++ b/FormFactory.Example/Views/Shared/FormFactory/Property.FormFactory.Example.Models.Titles.cshtml
@@ -1,0 +1,25 @@
+﻿@using FormFactory
+@model PropertyVm
+@{
+    var enumType = Nullable.GetUnderlyingType(Model.Type) ?? Model.Type;
+}
+@if (Model.IsWritable)
+{
+    <select name="@Model.Name" @(Model.IsWritable ? "" : "disabled=disabled")>
+        @if (Nullable.GetUnderlyingType(Model.Type) != null)
+        {
+            <option value="" @(Model.Value == null ? "selected=selected" : "")></option>
+        }
+        @foreach (var enumMember in Enum.GetValues(enumType))
+        {
+
+            var selected = (Model.Value != null && Model.Value.ToString() == enumMember.ToString());
+            <option value="@enumMember.ToString()" @(selected ? "selected=selected" : "")>@enumMember.ToString().</option>
+        }
+    </select>
+}
+else
+{
+    var displayValue = Model.Value == null ? null : Enum.Parse(enumType, Model.Value.ToString());
+    <span class="xlarge uneditable-input">@displayValue.ToString().</span>
+}

--- a/FormFactory/FormHelperExtension.cs
+++ b/FormFactory/FormHelperExtension.cs
@@ -102,9 +102,10 @@ namespace FormFactory
         {
             if (type == null) return null;
             getName = getName ?? (t => t.FullName);
-            var check = Nullable.GetUnderlyingType(type) ?? type; ;
+            var check = Nullable.GetUnderlyingType(type) ?? type;
+            
             Func<Type, string> getPartialViewName = t => (string.IsNullOrWhiteSpace(prefix) ? "" : (prefix + ".")) + getName(t);
-            string partialViewName = getPartialViewName(type);
+            string partialViewName = getPartialViewName(check);
 
             var engineResult = ViewEngines.Engines.FindPartialView(cc, partialViewName);
             while (engineResult.View == null && check.BaseType != null)


### PR DESCRIPTION
first view check was on "type", not the nullable-flattened "check". Example (/account/register) uses a nullable enum to demonstrate fix.
