### PR TITLE
Fixes DisplayNameAttribute being ignored

### DIFF
--- a/FormFactory/PropertyVm.cs
+++ b/FormFactory/PropertyVm.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 using FormFactory.Attributes;
+using System.ComponentModel;
 
 namespace FormFactory
 {
@@ -35,9 +36,9 @@ namespace FormFactory
                 .Any(x => x.CustomDataType == "Hidden");
             GetCustomAttributes = () => pi.GetCustomAttributes(true);
 
-            var descriptionAttr = pi.GetCustomAttributes(true).OfType<DisplayAttribute>()
-                .FirstOrDefault(x => !string.IsNullOrEmpty(x.Name));
-            DisplayName = descriptionAttr != null ? descriptionAttr.Name : pi.Name.Sentencise();
+            var descriptionAttr = pi.GetCustomAttributes(true).OfType<DisplayNameAttribute>()
+                .FirstOrDefault();
+            DisplayName = descriptionAttr != null ? descriptionAttr.DisplayName : pi.Name.Sentencise();
 
              
         }
@@ -58,9 +59,9 @@ namespace FormFactory
             IsHidden = pi.GetCustomAttributes(true).OfType<DataTypeAttribute>().Any(x => x.CustomDataType == "Hidden");
             GetCustomAttributes = () => pi.GetCustomAttributes(true);
 
-            var descriptionAttr = pi.GetCustomAttributes(true).OfType<DisplayAttribute>()
-                .FirstOrDefault(x => !string.IsNullOrEmpty(x.Name));
-            DisplayName = descriptionAttr != null ? descriptionAttr.Name : pi.Name.Sentencise();
+            var descriptionAttr = pi.GetCustomAttributes(true).OfType<DisplayNameAttribute>()
+                .FirstOrDefault();
+            DisplayName = descriptionAttr != null ? descriptionAttr.DisplayName : pi.Name.Sentencise();
 
              
         }
@@ -108,9 +109,9 @@ namespace FormFactory
             IsHidden = pi.GetCustomAttributes(true).OfType<DataTypeAttribute>()
                 .Any(x => x.CustomDataType == "Hidden");
 
-            var descriptionAttr = pi.GetCustomAttributes(true).OfType<DisplayAttribute>()
-                .FirstOrDefault(x => !string.IsNullOrEmpty(x.Name));
-            DisplayName = descriptionAttr != null ? descriptionAttr.Name : pi.Name.Sentencise();
+            var descriptionAttr = pi.GetCustomAttributes(true).OfType<DisplayNameAttribute>()
+                .FirstOrDefault();
+            DisplayName = descriptionAttr != null ? descriptionAttr.DisplayName : pi.Name.Sentencise();
             DataAttributes = new Dictionary<string, string>();
         }
 


### PR DESCRIPTION
This fixes the DisplayNameAttribute being ignored for all kind of properties. 
You can check it out by looking at the examples at http://formfactory.apphb.com/
The "Auto Complete" one has the second field that should have a label saying "Countrie" but instead it keeps showing "Country via ajax".

It would be nice if you could incorporate this PR and release a new package on nuget. 

Cheers!
