### PR TITLE
Update Property.System.String.cshtml template to set option value for…

### DIFF
--- a/FormFactory/Views/Shared/FormFactory/Property.System.String.cshtml
+++ b/FormFactory/Views/Shared/FormFactory/Property.System.String.cshtml
@@ -23,7 +23,7 @@
             var isSelected = Model.Value != null && option.Item2 == Model.Value.ToString();
             <div class="radio">
                 <label>
-                    <input type="radio" name="@Model.Name" value="option1" @Html.Raw(isSelected ? "checked" : "")>
+                    <input type="radio" name="@Model.Name" value="@option.Item1" @Html.Raw(isSelected ? "checked" : "")>
                     @option.Item1
                 </label>
             </div>

--- a/FormFactory/Views/Shared/FormFactory/Property.System.String.cshtml
+++ b/FormFactory/Views/Shared/FormFactory/Property.System.String.cshtml
@@ -23,7 +23,7 @@
             var isSelected = Model.Value != null && option.Item2 == Model.Value.ToString();
             <div class="radio">
                 <label>
-                    <input type="radio" name="@Model.Name" value="@option.Item1" @Html.Raw(isSelected ? "checked" : "")>
+                    <input type="radio" name="@Model.Name" value="@option.Item2" @Html.Raw(isSelected ? "checked" : "")>
                     @option.Item1
                 </label>
             </div>


### PR DESCRIPTION
Suggested update sets radio button options value to the displayed string. (Some users may prefer indexes instead?) All radio button options were hard coded as value="option1" . This makes it hard to retrieve the selected value on postback if reading the Request.Params . For example, without this change the examples page rendered the radio button list of OS choices to the following, showing all values set to 'option1':

&lt;div class="radio"&gt;
                &lt;label&gt;
                    &lt;input type="radio" name="os" value="option1" &gt;
                    OSX
                &lt;/label&gt;
            &lt;/div&gt;
            &lt;div class="radio"&gt;
                &lt;label&gt;
                    &lt;input type="radio" name="os" value="option1" &gt;
                    IOS
                &lt;/label&gt;
            &lt;/div&gt;
            &lt;div class="radio"&gt;
                &lt;label&gt;
                    &lt;input type="radio" name="os" value="option1" checked&gt;
                    Windows
                &lt;/label&gt;
            &lt;/div&gt;
            &lt;div class="radio"&gt;
                &lt;label&gt;
                    &lt;input type="radio" name="os" value="option1" &gt;
                    Android
                &lt;/label&gt;
            &lt;/div&gt;