### PR TITLE
Fix error message of RegularExpressionAttribute

### DIFF
--- a/FormFactory/Attributes/RegularExpressionAttribute.cs
+++ b/FormFactory/Attributes/RegularExpressionAttribute.cs
@@ -10,7 +10,7 @@ namespace FormFactory.Attributes
 
         public string FormatErrorMessage(string propertyVmDisplayName)
         {
-            return $"{propertyVmDisplayName} must be ${FriendlyFormat ?? $"match pattern '{Pattern}'"}";
+            return $"{propertyVmDisplayName} must {FriendlyFormat ? "be " + FriendlyFormat : "match pattern '{Pattern}'"}";
         }
 
         public string FriendlyFormat { get; set; }


### PR DESCRIPTION
Display was `must be $match pattern '\d+(\.\d{4})' `, which is not quite exact what I expected ;)